### PR TITLE
Add unit tests for VoxSynopsis

### DIFF
--- a/Tests/test_recording_thread.py
+++ b/Tests/test_recording_thread.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import numpy as np
+
+from vox_synopsis_fast_whisper import RecordingThread
+
+
+def test_process_audio_creates_file(tmp_path, monkeypatch):
+    audio_data = np.ones(48000, dtype=np.float32)
+    thread = RecordingThread(0, 1, str(tmp_path), True)
+
+    def fake_reduce_noise(*args, **kwargs):
+        return audio_data
+
+    written = {}
+
+    def fake_write(path: str, data: np.ndarray, sr: int) -> None:
+        written["path"] = path
+        written["data"] = data
+        written["sr"] = sr
+
+    monkeypatch.setattr(
+        "vox_synopsis_fast_whisper.nr.reduce_noise",
+        fake_reduce_noise,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "vox_synopsis_fast_whisper.sf.write",
+        fake_write,
+        raising=False,
+    )
+    thread.process_audio(str(tmp_path / "input.wav"), audio_data)
+    expected = tmp_path / "input_processed.wav"
+    assert written["path"] == str(expected)
+    assert np.array_equal(written["data"], audio_data)
+    assert written["sr"] == 48000

--- a/Tests/test_settings_dialog.py
+++ b/Tests/test_settings_dialog.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from PyQt5.QtWidgets import QApplication
+
+from vox_synopsis_fast_whisper import FastWhisperSettingsDialog
+
+
+def test_get_settings_returns_updated_values(monkeypatch):
+    _ = QApplication.instance() or QApplication([])
+    dialog = FastWhisperSettingsDialog({"model": "medium"})
+    dialog.model_combo.setCurrentText("small")
+    dialog.language_combo.setCurrentText("en")
+    dialog.device_combo.setCurrentText("cpu")
+    dialog.compute_type_combo.setCurrentText(dialog.compute_type_combo.itemText(0))
+    dialog.vad_filter_checkbox.setChecked(False)
+    dialog.temperature_slider.setValue(5)
+    dialog.best_of_slider.setValue(3)
+    dialog.beam_size_slider.setValue(3)
+    dialog.condition_checkbox.setChecked(False)
+    dialog.initial_prompt_edit.setText("hello")
+    dialog.acceleration_spinbox.setValue(2.0)
+    settings = dialog.get_settings()
+
+    assert settings["model"] == "small"
+    assert settings["language"] == "en"
+    assert settings["device"] == "cpu"
+    assert settings["vad_filter"] is False
+    assert settings["temperature"] == 0.5
+    assert settings["best_of"] == 3
+    assert settings["beam_size"] == 3
+    assert settings["condition_on_previous_text"] is False
+    assert settings["initial_prompt"] == "hello"
+    assert settings["acceleration_factor"] == 2.0

--- a/Tests/test_stylesheet.py
+++ b/Tests/test_stylesheet.py
@@ -1,0 +1,27 @@
+from vox_synopsis_fast_whisper import load_stylesheet
+
+
+class DummyApp:
+    def __init__(self) -> None:
+        self.style = ""
+
+    def setStyleSheet(self, style: str) -> None:  # noqa: N802 - Qt style
+        self.style = style
+
+
+def test_load_stylesheet_success(tmp_path, monkeypatch):
+    style_path = tmp_path / "style.qss"
+    style_content = "QWidget { color: red; }"
+    style_path.write_text(style_content)
+    monkeypatch.chdir(tmp_path)
+    app = DummyApp()
+    load_stylesheet(app)
+    assert app.style == style_content
+
+
+def test_load_stylesheet_missing(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    app = DummyApp()
+    load_stylesheet(app)
+    captured = capsys.readouterr()
+    assert "style.qss" in captured.out

--- a/vox_synopsis_fast_whisper.py
+++ b/vox_synopsis_fast_whisper.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 import sys
 import time
+from typing import Any
 
 import noisereduce as nr
 import numpy as np
@@ -48,7 +49,6 @@ OUTPUT_DIR = "gravacoes"
 
 
 # --- Função para carregar o stylesheet ---
-from typing import Any
 
 
 def load_stylesheet(app: Any) -> None:
@@ -640,7 +640,9 @@ class AudioRecorderApp(QMainWindow, Ui_MainWindow):
 # --- Diálogo de Configurações (sem alteração) ---
 class FastWhisperSettingsDialog(QDialog):
     # ... (lógica do diálogo de configurações permanece a mesma)
-    def __init__(self, current_settings: dict[str, Any], parent: QWidget | None = None) -> None:
+    def __init__(
+        self, current_settings: dict[str, Any], parent: QWidget | None = None
+    ) -> None:
         super().__init__(parent)
         self.setWindowTitle("Configurações do FastWhisper")
         self.setFixedSize(600, 650)


### PR DESCRIPTION
## Summary
- add tests for stylesheet loader
- add tests for RecordingThread processing
- add tests for settings dialog behavior
- clean up imports and long lines in `vox_synopsis_fast_whisper.py`
- ensure repository passes ruff and pyright

## Testing
- `ruff check .`
- `pyright`

------
https://chatgpt.com/codex/tasks/task_e_6866b6e8c7308326bf2a06b50c3b6a46