### PR TITLE
Fix broken link in docs index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ Esta documentação é organizada com base nos arquivos fonte do projeto. Cada a
 ### Arquivos Fonte Principais e Sua Documentação
 
 - **[`vox_synopsis_fast_whisper.py`](./vox_synopsis_fast_whisper.md)**: O coração da aplicação. Contém a lógica da interface gráfica (GUI), coordena a gravação de áudio, gerencia as threads de transcrição com Fast Whisper e lida com as interações do usuário.
-- **[`ui_vox_synopsis.py`](./ui_vox_synopsis.md)**: Define a estrutura da interface gráfica (esqueleto da UI) gerada a partir do Qt Designer. Não deve ser editado manualmente.
+<!-- - **[`ui_vox_synopsis.py`](./ui_vox_synopsis.md)**: Define a estrutura da interface gráfica (esqueleto da UI) gerada a partir do Qt Designer. Não deve ser editado manualmente. -->
 - **[`style.qss`](./style.qss.md)**: Arquivo de folha de estilos Qt (QSS) responsável pela personalização visual e tema da aplicação.
 
 ### Documentação dos Testes Unitários


### PR DESCRIPTION
## Summary
- remove invalid entry in `docs/index.md`

## Testing
- `ruff check .`
- `pyright` *(fails: "availableGeometry" is not a known attribute of "None")*

------
https://chatgpt.com/codex/tasks/task_e_6869440fd1a48326b8d8579b703e28ec